### PR TITLE
setup: fix typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     download_url="https://github.com/yvesf/fuse-httpfs/archive/v{}.tar.gz".format(version),
     license='LICENSE.txt',
     description='A fuse filesystem for common http Index of pages.',
-    long_description=open('README.txt').read(),
+    long_description=open('README.md').read(),
     install_requires=[
         "fusepy",
         "requests",


### PR DESCRIPTION
This nasty typo prevented the package from being install via:

``` bash
pip install --user git+https://github.com/yvesf/fuse-httpfs.git@master
```
